### PR TITLE
[FE] NotAllow 범용성 갖추기 

### DIFF
--- a/fe/src/hoc/PrivateRoute.tsx
+++ b/fe/src/hoc/PrivateRoute.tsx
@@ -12,6 +12,10 @@ export default function PrivateRoute({ Component, isLogin }: PrivateRouteProps) 
   return isLogin ? (
     <Component />
   ) : (
-    <NotAllow warnMessage="로그인하지 않은 유저는 접근할 수 없다." />
+    <NotAllow
+      warnMessage="로그인하지 않은 유저는 접근할 수 없다."
+      fallbackButtonMessage={'로그인 페이지로 이동'}
+      fallbackPath={'/login'}
+    />
   );
 }

--- a/fe/src/hoc/PublicRoute.tsx
+++ b/fe/src/hoc/PublicRoute.tsx
@@ -12,7 +12,11 @@ interface PublicRouteProps {
 // restricted = true => 로그인한 유저는 못들어감 (회원가입 페이지, 로그인 페이지)
 export default function PublicRoute({ Component, isLogin, restricted }: PublicRouteProps) {
   return isLogin && restricted ? (
-    <NotAllow warnMessage="로그인한 유저는 접근할 수 없다." />
+    <NotAllow
+      warnMessage="로그인한 유저는 접근할 수 없다."
+      fallbackButtonMessage={'홈으로 이동'}
+      fallbackPath={'/'}
+    />
   ) : (
     <Component />
   );

--- a/fe/src/pages/NotAllow/index.tsx
+++ b/fe/src/pages/NotAllow/index.tsx
@@ -1,15 +1,25 @@
 import { useNavigate } from 'react-router-dom';
 
-export default function NotAllow({ warnMessage }: { warnMessage: string }) {
+interface NotAllowProps {
+  warnMessage: string;
+  fallbackButtonMessage: string;
+  fallbackPath: string;
+}
+
+export default function NotAllow({
+  warnMessage,
+  fallbackButtonMessage,
+  fallbackPath,
+}: NotAllowProps) {
   const navigate = useNavigate();
-  const backToMain = () => {
-    navigate('/');
+  const OnClickFallbackButton = () => {
+    navigate(fallbackPath);
   };
   return (
     <div>
       NotAllow
       <h1>{warnMessage}</h1>
-      <button onClick={backToMain}>홈으로 돌아가기</button>
+      <button onClick={OnClickFallbackButton}>{fallbackButtonMessage}</button>
     </div>
   );
 }


### PR DESCRIPTION
### About

리뷰 반영

[만약 계정설정 페이지가 있다면 로그인 한 유저에게는 계정설정페이지로 redirect를 시켜도 괜찮을 것 같네요! ](https://github.com/codesquad-members-2022/issue-tracker/pull/11#discussion_r898211885)

[NotAllow페이지에서는 home페이지로 이동하는 버튼이 보이는데요
로그인 하지 않은 사용자에게는 바로 로그인 할 수 있는 화면을 보여주는 건 어떨까요?](https://github.com/codesquad-members-2022/issue-tracker/pull/11#discussion_r898218919)

### Description

warnMessage 외에도
fallbackButtonMessage, fallbackPath를 props로 전달받기

```tsx
import { useNavigate } from 'react-router-dom';

interface NotAllowProps {
  warnMessage: string;
  fallbackButtonMessage: string;
  fallbackPath: string;
}

export default function NotAllow({
  warnMessage,
  fallbackButtonMessage,
  fallbackPath,
}: NotAllowProps) {
  const navigate = useNavigate();
  const OnClickFallbackButton = () => {
    navigate(fallbackPath);
  };
  return (
    <div>
      NotAllow
      <h1>{warnMessage}</h1>
      <button onClick={OnClickFallbackButton}>{fallbackButtonMessage}</button>
    </div>
  );
}

```

### Ref

#10 
