### PR TITLE
[FE] svg icon 컴포넌트 리팩토링

### DIFF
--- a/fe/src/App.tsx
+++ b/fe/src/App.tsx
@@ -25,7 +25,7 @@ import {
 
 // TODO: isLogin이라는 util 메서드를 만들어서 로그인 여부를 boolean으로 반환하기
 export default function App() {
-  const isLogin = false;
+  const isLogin = true;
   return (
     <BrowserRouter>
       <Routes>

--- a/fe/src/App.tsx
+++ b/fe/src/App.tsx
@@ -13,6 +13,7 @@ import PrivateRoute from '@/hoc/PrivateRoute';
 import PublicRoute from '@/hoc/PublicRoute';
 import {
   Buttons,
+  Icons,
   IssueDetail,
   Issues,
   Labels,
@@ -31,6 +32,7 @@ export default function App() {
       <Routes>
         <Route path={HOME_ROUTE} element={<Navigate to={ISSUES_ROUTE} replace />} />
         <Route path="/buttons" element={<Buttons />} />
+        <Route path="/icons" element={<Icons />} />
         <Route path="/textInputs" element={<TextInputs />} />
 
         <Route

--- a/fe/src/assets/icons/index.ts
+++ b/fe/src/assets/icons/index.ts
@@ -3,6 +3,17 @@ import boxCloseIssue from './box-close-issue.svg';
 import cancelX from './cancel-x.svg';
 import circleCheck from './circle-check.svg';
 import circleEmpty from './circle-empty.svg';
+import Edit from './edit.svg';
+import ExClamationBlue from './exclamation-blue.svg';
+import ExClamationNormal from './exclamation-normal.svg';
+import Label from './label.svg';
+import MilseStone from './milestone.svg';
+import PaperClip from './paperclip.svg';
+import Plus from './plus.svg';
+import Refresh from './refresh.svg';
+import Search from './search.svg';
+import SmileEmoji from './smile-emoji.svg';
+import Trash from './trash.svg';
 
 export const Icons = {
   angleDown,
@@ -10,6 +21,17 @@ export const Icons = {
   cancelX,
   circleCheck,
   circleEmpty,
+  Edit,
+  ExClamationBlue,
+  ExClamationNormal,
+  Label,
+  MilseStone,
+  PaperClip,
+  Plus,
+  Refresh,
+  Search,
+  SmileEmoji,
+  Trash,
 } as const;
 
 export type IconsType = keyof typeof Icons;

--- a/fe/src/components/Common/Button/index.tsx
+++ b/fe/src/components/Common/Button/index.tsx
@@ -1,8 +1,6 @@
 import { ReactNode } from 'react';
 import { CSSProp } from 'styled-components';
 
-import { OverridableProps } from '@/utils/type';
-
 import * as S from './style';
 
 export interface ButtonProps {

--- a/fe/src/components/Common/Icon/index.tsx
+++ b/fe/src/components/Common/Icon/index.tsx
@@ -21,13 +21,12 @@ export default function Icon({
       css`
         ${theme.iconSizes[iconSize]}
       `}
+
     & path {
       /* fill: backgroundColor */
-      stroke: ${({ theme }) => theme.colors.greyscale.label};
+      /* stroke: border(line) color */
     }
-    &:hover path {
-      stroke: ${({ theme }) => theme.colors.greyscale.titleActive};
-    }
+
     ${customStyle &&
     css`
       ${customStyle};

--- a/fe/src/components/Common/Icon/index.tsx
+++ b/fe/src/components/Common/Icon/index.tsx
@@ -1,15 +1,19 @@
+import styled, { css } from 'styled-components';
+
 import { Icons, IconsType } from '@/assets/icons';
 import { IconSizeTypes } from '@/styles/theme';
 
-import * as S from './style';
-
 export interface IconPropsType {
   iconName: IconsType;
-  iconSize: keyof IconSizeTypes;
+  iconSize?: keyof IconSizeTypes;
 }
 
-const Icon = ({ iconName, iconSize }: IconPropsType) => {
-  return <S.Icon src={Icons[iconName]} size={iconSize} alt={iconName} />;
-};
-
-export default Icon;
+export default function Icon({ iconName, iconSize = 'base' }: IconPropsType) {
+  const StyledIcon = styled(Icons[iconName])`
+    ${({ theme }) =>
+      css`
+        ${theme.iconSizes[iconSize]}
+      `}
+  `;
+  return <StyledIcon />;
+}

--- a/fe/src/components/Common/Icon/index.tsx
+++ b/fe/src/components/Common/Icon/index.tsx
@@ -1,4 +1,4 @@
-import styled, { css } from 'styled-components';
+import styled, { css, CSSProp } from 'styled-components';
 
 import { Icons, IconsType } from '@/assets/icons';
 import { IconSizeTypes } from '@/styles/theme';
@@ -6,14 +6,32 @@ import { IconSizeTypes } from '@/styles/theme';
 export interface IconPropsType {
   iconName: IconsType;
   iconSize?: keyof IconSizeTypes;
+  className?: string;
+  customStyle?: CSSProp | null | undefined;
 }
 
-export default function Icon({ iconName, iconSize = 'base' }: IconPropsType) {
+export default function Icon({
+  iconName,
+  iconSize = 'base',
+  className,
+  customStyle,
+}: IconPropsType) {
   const StyledIcon = styled(Icons[iconName])`
     ${({ theme }) =>
       css`
         ${theme.iconSizes[iconSize]}
       `}
+    & path {
+      /* fill: backgroundColor */
+      stroke: ${({ theme }) => theme.colors.greyscale.label};
+    }
+    &:hover path {
+      stroke: ${({ theme }) => theme.colors.greyscale.titleActive};
+    }
+    ${customStyle &&
+    css`
+      ${customStyle};
+    `}
   `;
-  return <StyledIcon />;
+  return <StyledIcon className={className} />;
 }

--- a/fe/src/components/Common/Icon/style.ts
+++ b/fe/src/components/Common/Icon/style.ts
@@ -1,7 +1,0 @@
-import styled from 'styled-components';
-
-import { IconSizeTypes } from '@/styles/theme';
-
-export const Icon = styled.img<{ size: keyof IconSizeTypes }>``;
-// FIXME: 타입에러
-// /* ${({ theme }) => theme.iconSizes[]} */

--- a/fe/src/components/Common/TextInput/index.tsx
+++ b/fe/src/components/Common/TextInput/index.tsx
@@ -1,5 +1,7 @@
 import { useState, InputHTMLAttributes } from 'react';
 
+import { TextInputSizesTypes } from '@/styles/theme';
+
 import * as S from './style';
 
 // FIXME: success type 추가되도록 error 로직 변경, 현재 error 상태만 확인하기 위한 임시 로직
@@ -7,7 +9,7 @@ import * as S from './style';
 interface TextInputProps extends InputHTMLAttributes<HTMLInputElement> {
   label?: string;
   error?: string;
-  textInputSize: 'large' | 'medium' | 'small';
+  textInputSize: keyof TextInputSizesTypes;
 }
 export default function TextInput({
   label,

--- a/fe/src/components/Common/TextInput/style.ts
+++ b/fe/src/components/Common/TextInput/style.ts
@@ -1,6 +1,8 @@
 import styled, { css } from 'styled-components';
 
-export const TextInput = styled.div<{ textInputSize: string; isError: boolean }>`
+import { TextInputSizesTypes } from '@/styles/theme';
+
+export const TextInput = styled.div<{ textInputSize: keyof TextInputSizesTypes; isError: boolean }>`
   display: flex;
   align-items: center;
   background-color: ${({ theme }) => theme.colors.greyscale.inputBackground};

--- a/fe/src/custom.d.ts
+++ b/fe/src/custom.d.ts
@@ -1,4 +1,5 @@
 declare module '*.svg' {
-  const content: any;
-  export default content;
+  import React from 'react';
+  const SVG: React.VFC<React.SVGProps<SVGSVGElement>>;
+  export default SVG;
 }

--- a/fe/src/mocks/issue/index.ts
+++ b/fe/src/mocks/issue/index.ts
@@ -5,7 +5,7 @@ import { mockIssueList, mockIssueDetail } from '@/mocks/issue/data';
 
 const issueHandler = [
   rest.get(API_PREFIX + ISSUE_API.ISSUES, (req, res, ctx) => {
-    return res(ctx.status(400), ctx.json(mockIssueList));
+    return res(ctx.status(200), ctx.json(mockIssueList));
   }),
   rest.get(`${API_PREFIX}/${ISSUE_API.ISSUES}/:id`, (req, res, ctx) => {
     return res(ctx.status(200), ctx.json(mockIssueDetail));

--- a/fe/src/pages/Buttons/index.tsx
+++ b/fe/src/pages/Buttons/index.tsx
@@ -1,4 +1,5 @@
 import { Button, TextButton } from '@/components/Common/Button';
+import Icon from '@/components/Common/Icon';
 import { GithubLoginButton, SmallButon } from '@/pages/Login/style';
 
 export default function Buttons() {
@@ -15,6 +16,7 @@ export default function Buttons() {
       <Button isSecondary onClick={() => {}}>
         Button
       </Button>
+      <Icon iconName="angleDown" />
       <TextButton onClick={() => {}}>TextButton</TextButton>
     </div>
   );

--- a/fe/src/pages/Buttons/index.tsx
+++ b/fe/src/pages/Buttons/index.tsx
@@ -16,7 +16,6 @@ export default function Buttons() {
       <Button isSecondary onClick={() => {}}>
         Button
       </Button>
-      <Icon iconName="angleDown" />
       <TextButton onClick={() => {}}>TextButton</TextButton>
     </div>
   );

--- a/fe/src/pages/Icons/index.tsx
+++ b/fe/src/pages/Icons/index.tsx
@@ -1,0 +1,24 @@
+import Icon from '@/components/Common/Icon';
+
+export default function Icons() {
+  return (
+    <div style={{ display: 'flex', gap: '12px', width: '100vw', height: '100vh' }}>
+      <Icon iconName="angleDown" iconSize="large" />
+      <Icon iconName="boxCloseIssue" iconSize="small" />
+      <Icon iconName="cancelX" iconSize="base" />
+      <Icon iconName="circleCheck" iconSize="star" />
+      <Icon iconName="circleEmpty" iconSize="account" />
+      <Icon iconName="Edit" iconSize="large" />
+      <Icon iconName="ExClamationBlue" iconSize="small" />
+      <Icon iconName="ExClamationNormal" iconSize="base" />
+      <Icon iconName="Label" iconSize="star" />
+      <Icon iconName="MilseStone" iconSize="account" />
+      <Icon iconName="PaperClip" iconSize="large" />
+      <Icon iconName="Plus" iconSize="small" />
+      <Icon iconName="Refresh" iconSize="base" />
+      <Icon iconName="Search" iconSize="star" />
+      <Icon iconName="SmileEmoji" iconSize="account" />
+      <Icon iconName="Trash" iconSize="large" />
+    </div>
+  );
+}

--- a/fe/src/pages/index.ts
+++ b/fe/src/pages/index.ts
@@ -1,4 +1,5 @@
 import Buttons from './Buttons';
+import Icons from './Icons';
 import IssueDetail from './IssueDetail';
 import Issues from './Issues';
 import Labels from './Labels';
@@ -20,4 +21,5 @@ export {
   NotAllow,
   Buttons,
   TextInputs,
+  Icons,
 };

--- a/fe/src/styles/styled.d.ts
+++ b/fe/src/styles/styled.d.ts
@@ -1,6 +1,6 @@
 import 'styled-components';
 
-import { ColorsTypes, FontTypes, IconSizeTypes } from './theme';
+import { ColorsTypes, FontTypes, IconSizeTypes, TextInputSizesTypes } from './theme';
 
 declare module 'styled-components' {
   export interface DefaultTheme {
@@ -8,6 +8,6 @@ declare module 'styled-components' {
     fonts: FontTypes;
     iconSizes: IconSizeTypes;
     buttonSizes: ButtonSizeTypes;
-    textInputSizes: TextInputTypes;
+    textInputSizes: TextInputSizesTypes;
   }
 }

--- a/fe/src/styles/theme/icon.ts
+++ b/fe/src/styles/theme/icon.ts
@@ -1,7 +1,24 @@
+import { css } from 'styled-components';
+
 export const iconSizes = {
-  small: '12rem',
-  star: '16rem',
-  base: '24rem',
-  large: '30rem',
-  account: '76rem',
+  small: css`
+    width: 1.4rem;
+    height: 1.4rem;
+  `,
+  star: css`
+    width: 1.6rem;
+    height: 1.6rem;
+  `,
+  base: css`
+    width: 1.8rem;
+    height: 1.8rem;
+  `,
+  large: css`
+    width: 3.2rem;
+    height: 3.2rem;
+  `,
+  account: css`
+    width: 5.6rem;
+    height: 5.6rem;
+  `,
 };

--- a/fe/src/styles/theme/index.ts
+++ b/fe/src/styles/theme/index.ts
@@ -10,7 +10,7 @@ export type ColorsTypes = typeof colors;
 export type FontTypes = typeof fonts;
 export type IconSizeTypes = typeof iconSizes;
 export type ButtonSizeTypes = typeof buttonSizes;
-export type TextInputSizes = typeof textInputSizes;
+export type TextInputSizesTypes = typeof textInputSizes;
 
 export const theme: DefaultTheme = {
   colors,

--- a/fe/webpack/webpack.common.js
+++ b/fe/webpack/webpack.common.js
@@ -20,7 +20,19 @@ module.exports = {
     rules: [
       {
         test: /\.svg$/,
-        use: ['@svgr/webpack'],
+        use: {
+          loader: '@svgr/webpack',
+          options: {
+            svgoConfig: {
+              plugins: [
+                {
+                  name: 'removeViewBox',
+                  active: false,
+                },
+              ],
+            },
+          },
+        },
       },
     ],
   },


### PR DESCRIPTION
### About

1. TextInputSizesTypes 타입지정

2. svg icon 컴포넌트 리팩토링


### Description

### 1. TextInputSizesTypes 타입지정

- `styles/styled.d.ts`에 `TextInputSizesTypes`가 import가 안되어 있어서 추가했습니다. 
- 타입을 지정하니 아래 파일에서 에러가 발생해  `textInputSize: string: ->  keyof TextInputSizesTypes`로 수정했습니다. 

### Result

```ts
// components/common/TextInput.style.ts

import { TextInputSizesTypes } from '@/styles/theme';

export const TextInput = styled.div<{ textInputSize: keyof TextInputSizesTypes; isError: boolean }>`
  ${({ textInputSize, theme }) =>
    css`
      ${theme.textInputSizes[textInputSize]}
    `}
`;

```


### 2. svg icon 컴포넌트 리팩토링

- svg파일의 custom type지정
- webpack의 @svg/webpack 플러그인 속성을 추가해 svg의 viewBox 초기화 -> custom width, height 가능하게 수정
- Icon컴포넌트 props로  iconName,  iconSize,  className,  customStyle 추가

### Result

```ts
// assets/Icons/idnex.ts
import angleDown from './angle-down.svg';

export const Icons = {
 angleDown, 
 // 생략
} as const;

export type IconsType = keyof typeof Icons;

// components/Common/Icon/index.tsx
import styled from 'styled-components';

export default function Icon({
  iconName,
  iconSize = 'base',
  className,
  customStyle,
}: IconPropsType) {
  const StyledIcon = styled(Icons[iconName])`
    ${({ theme }) =>
      css`
        ${theme.iconSizes[iconSize]}
      `}

    & path {
      /* fill: backgroundColor */
      /* stroke: border(line) color */
    }

    ${customStyle &&
    css`
      ${customStyle};
    `}
  `;
  return <StyledIcon className={className} />;
}

// src/custom.d.ts
declare module '*.svg' {
  import React from 'react';
  const SVG: React.VFC<React.SVGProps<SVGSVGElement>>;
  export default SVG;
}
```
<img width="458" alt="스크린샷 2022-06-21 오후 11 38 31" src="https://user-images.githubusercontent.com/71386219/174827026-6df44c90-f70b-4d84-871a-cdad2f13435f.png">



### Ref

#32 